### PR TITLE
Updated dockerfile

### DIFF
--- a/OptiTypePipeline.py
+++ b/OptiTypePipeline.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding=utf-8
+
 """
 ###################################################################
 
@@ -96,6 +97,7 @@ optional arguments:
                         be written
   --verbose, -v         Set verbose mode on.
 """
+
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,12 @@
+[mapping]
+razers3=/usr/local/bin/razers3
+threads=1
+
+[ilp]
+solver=cbc
+threads=1
+
+[behavior]
+deletebam=true
+unpaired_weight=0
+use_discordant=false


### PR DESCRIPTION
Biocontainers latest repo uses python3.7 as standard python version which is not compatible with Optitype. Hence container at [quay.io](https://quay.io/repository/biocontainers/optitype?tab=tags) was using python3 instead of python2 to run the script. 
Additions to Dockerfile:
Added Install requirements for razers3 too. 
Use a COPY to move data over, install python modules into root.
Removed ENTRYPOINT for CWL compatibility.