### PR TITLE
Fix potential output name collisions

### DIFF
--- a/OptiTypePipeline.py
+++ b/OptiTypePipeline.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
     else:
         extension = 'sam'
 
-    bam_paths = args.input if bam_input else [os.path.join(out_dir, ("%s_%i.%s" % (date, i+1, extension))) for i in range(len(args.input))]
+    bam_paths = args.input if bam_input else [os.path.join(out_dir, ("%s_%i.%s" % (prefix, i+1, extension))) for i in range(len(args.input))]
 
     # SETUP variables and OUTPUT samples
     ref_type = "nuc" if args.rna else "gen"


### PR DESCRIPTION
The pipeline currently generates temporary output files that are named after the current date and time. When the pipeline is launched multiple times in a short period of time by a workflow engine, this results in collisions.

This patch adds the same prefix to the temporary bam files as for the output. Collisions can thus be prevented by using `--prefix`